### PR TITLE
Security: bump actionview, activesupport, nokogiri, uri, yard

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,20 +12,20 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    actionview (8.0.2)
-      activesupport (= 8.0.2)
+    actionview (8.1.3)
+      activesupport (= 8.1.3)
       builder (~> 3.1)
       erubi (~> 1.11)
       rails-dom-testing (~> 2.2)
       rails-html-sanitizer (~> 1.6)
-    activesupport (8.0.2)
+    activesupport (8.1.3)
       base64
-      benchmark (>= 0.3)
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
+      json
       logger (>= 1.4.2)
       minitest (>= 5.1)
       securerandom (>= 0.3)
@@ -67,23 +67,19 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     method_source (1.1.0)
-    mini_portile2 (2.8.9)
     minitest (5.25.5)
     netrc (0.11.0)
-    nokogiri (1.18.5)
-      mini_portile2 (~> 2.8.2)
+    nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.5-aarch64-linux-gnu)
+    nokogiri (1.19.4-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.18.5-aarch64-linux-musl)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.5-arm64-darwin)
+    nokogiri (1.19.4-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.5-x86_64-darwin)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.18.5-x86_64-linux-gnu)
-      racc (~> 1.4)
-    nokogiri (1.18.5-x86_64-linux-musl)
+    nokogiri (1.19.4-x86_64-linux-musl)
       racc (~> 1.4)
     packs-specification (0.0.10)
       sorbet-runtime
@@ -204,8 +200,8 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
-    uri (1.0.3)
-    yard (0.9.37)
+    uri (1.1.1)
+    yard (0.9.44)
     yard-sorbet (0.9.0)
       sorbet-runtime
       yard
@@ -216,7 +212,6 @@ PLATFORMS
   aarch64-linux-gnu
   aarch64-linux-musl
   arm64-darwin
-  ruby
   universal-darwin
   x86_64-darwin
   x86_64-linux


### PR DESCRIPTION
## Summary

Security update addressing multiple CVEs across 5 gems.

| Gem | Old | New | GHSA | Severity |
|-----|-----|-----|------|----------|
| actionview | 8.0.2 | 8.1.3 | GHSA-v55j-83pf-r9cq | - |
| activesupport | 8.0.2 | 8.1.3 | GHSA-2j26-frm8-cmj9, GHSA-89vf-4333-qx8v, GHSA-cg4j-q9v8-6v38 | - |
| nokogiri | 1.18.5 | 1.19.4 | GHSA-v2fc-qm4h-8hqv, GHSA-c4rq-3m3g-8wgx, GHSA-wx95-c6cv-8532, GHSA-353f-x4gh-cqq8, GHSA-5w6v-399v-w3cc | - |
| uri | 1.0.3 | 1.1.1 | GHSA-j4pr-3wm6-xx2r | - |
| yard | 0.9.37 | 0.9.44 | GHSA-3jfp-46x4-xgfj | - |

**Note:** No major-version bumps — all updates are within the same major version series (Rails 8.x, nokogiri 1.x).

## Testing

- [x] rspec: 60 examples, 0 failures
- [x] rubocop: all checks passing