### PR TITLE
Require Ruby >= 3.3 and update CI Ruby versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
 
       - name: Determine release type
         id: version

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ plugins:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.3
   SuggestExtensions: false
   NewCops: enable
   Exclude:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -232,4 +232,4 @@ DEPENDENCIES
   tapioca
 
 BUNDLED WITH
-   2.6.5
+   4.0.15

--- a/query_packwerk.gemspec
+++ b/query_packwerk.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = 'Query Packwerk violations and dependencies.'
   spec.homepage = 'https://github.com/rubyatscale/query_packwerk'
   spec.license = 'MIT'
-  spec.required_ruby_version = '>= 3.1.0'
+  spec.required_ruby_version = '>= 3.3'
 
   spec.metadata['allowed_push_host'] = 'https://rubygems.org'
 


### PR DESCRIPTION
## Summary

Bumps the minimum supported Ruby version to 3.3 (Ruby 3.2 is now EOL) and refreshes Ruby version configuration.

Changes in this repo:
- **`query_packwerk.gemspec`**: `required_ruby_version` bumped from `'>= 3.1.0'` to `'>= 3.3'`.
- **`.rubocop.yml`**: `TargetRubyVersion` bumped from `3.1` to `3.3`.
- **`.github/workflows/release.yml`**: the `ruby/setup-ruby` step in the `tag` job, pinned to `ruby-version: 3.2`, bumped to `3.3`.

Note: `.github/workflows/ci.yml` already tested against `3.3` and `3.4` only, so its matrix needed no changes.

## Motivation

Resolves the Ruby version restrictions from rubyatscale/pack_stats#56, where supporting EOL Ruby forced older/vulnerable transitive dependencies. The supported set going forward is Ruby 3.3 and 3.4.



## Bundler

Also bumps `BUNDLED WITH` in `Gemfile.lock` to bundler **4.0.15** (latest). The previously pinned bundler version crashes on Ruby `head` (`NameError: uninitialized constant Pathname::SEPARATOR_PAT`) — see [this failing run](https://github.com/rubyatscale/code_manifest/actions/runs/28200903631/job/83539858239?pr=12). Pinning the current bundler resolves it.