### PR TITLE
Restrict GITHUB_TOKEN permissions in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,5 +8,7 @@ on:
 
 jobs:
   call-workflow-from-shared-config:
+    permissions:
+      contents: read
     uses: rubyatscale/shared-config/.github/workflows/ci.yml@main
     secrets: inherit


### PR DESCRIPTION
## Summary
- Resolves code scanning alert [#2](https://github.com/rubyatscale/query_packwerk/security/code-scanning/2) (`actions/missing-workflow-permissions`): the `call-workflow-from-shared-config` job in `ci.yml` had no explicit `permissions` block, so it defaulted to the repository's token permissions.
- Added `permissions: contents: read` on the job. The called reusable workflow (`rubyatscale/shared-config/.github/workflows/ci.yml`) only checks out code (with `persist-credentials: false`) and posts failure notifications via a Slack webhook secret — neither needs write access to `GITHUB_TOKEN`.

## Test plan
- [ ] Confirm the `CI` workflow still passes (tests, type check, lint) after merge
- [ ] Confirm code scanning alert #2 is auto-resolved on the next `CodeQL` run against `main`